### PR TITLE
Create /mnt/userfs folder before doing the firmware upgrade.

### DIFF
--- a/Upgrade-Firmware.sls
+++ b/Upgrade-Firmware.sls
@@ -1,6 +1,6 @@
 Deploy_firmware_file:
   file.managed:
-    - source: salt://FirmwareUpgrade/9056/cRIO-9056_8.0.0.cfg
+    - source: salt://FirmwareUpgrade/9068/cRIO-9068_8.0.0.cfg
     - name: /safemode/safemode.cfg
     - makedirs: True
     - replace: True
@@ -9,6 +9,11 @@ Deploy_firmware_file:
 Remove_salt_cache_volatile:
   file.absent:
     - name: /var/volatile/cache/salt/minion/files/base/
+
+Create_userfs_folder:
+  file.directory:
+    - name: /mnt/userfs
+    - makedirs: True
 
 Install_firmware:
   cmd.run:


### PR DESCRIPTION
    This folder is needed for niinstallsafemode to run correctly on latest
    OS versions on Arm targets. I don't delete it after the upgrade since the script will
    clean any file it puts into that folder. And I don't want to remove the
    folder since in theory can be created by the user and contain other
    files.

    This is a workaround since the already released versions of OS contain
    the version of niinstallsafemode script that doesn't work on Arm
    targets. RT Team said that this script should be designed to work on
    run-mode as well (I will create a bug on their side to fix this particular issue)
    so I am still discussing with them what are the implications and what
    this commitment would mean.

    Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>
